### PR TITLE
Add strategy matrix version to cache key

### DIFF
--- a/.github/workflows/ci-docker-image.yml
+++ b/.github/workflows/ci-docker-image.yml
@@ -1,12 +1,9 @@
 name: Docker Image CI
-
 on: push
-
 env:
   DOCKERHUB_USER: akospasztor
 
 jobs:
-
   build:
     strategy:
       matrix:
@@ -15,24 +12,21 @@ jobs:
         include:
           - os: linux
             runner: ubuntu-20.04
-
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
     - name: Setup docker buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
-
     - name: Cache docker layers
       uses: actions/cache@v2
       with:
         path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ matrix.version }}-${{ github.sha }}
         restore-keys: |
+          ${{ runner.os }}-buildx-${{ matrix.version }}-
           ${{ runner.os }}-buildx-
-
     - name: Docker metadata
       id: docker_meta
       uses: docker/metadata-action@v3
@@ -44,13 +38,11 @@ jobs:
         tags: |
           type=raw,value=latest
           type=semver,pattern={{version}}
-
     - name: Login to dockerhub
       uses: docker/login-action@v1
       with:
         username: ${{ env.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_PAT }}
-
     - name: Build docker image
       id: docker_build
       uses: docker/build-push-action@v2


### PR DESCRIPTION
This PR improves the docker cache performance on CI.

Currently each build shares the same cache key which allows only one docker build job from the build matrix to create a cache. This results in only one build job benefitting from the cache and all other jobs need to build the entire docker image from scratch. This can be improved by adding the version of the build strategy matrix to the cache key, resulting in an individual cache for all docker images.

Closes #5.